### PR TITLE
Mark as library for ModMenu

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -13,5 +13,10 @@
     "environment": "*",
     "mixins": [
         "langfiles-plus.mixins.json"
-    ]
+    ],
+    "custom": {
+        "modmenu": {
+            "badges": [ "library" ]
+        }
+    }
 }


### PR DESCRIPTION
ModMenu includes a filter to hide mods that are libraries, so that the mod list is less cluttered.

This just adds the required data in the fabric.mod.json so that ModMenu knows LangFilesPlus is a library.

Just so happened that I noticed it when going through the modlist to show the mods I used to someone.

For me it was the mod [Mod-erate Loading Screen](https://modrinth.com/mod/mod-loading-screen) using LangFilesPlus.
Congrats on such a simple and useful tool, when using Github code search to find where the entry may come from, I noticed that (at least) 21 projects import your mod.
